### PR TITLE
Duplication of loop-index variable added with --expandAllArraysConcurrent

### DIFF
--- a/src/pyft/statements.py
+++ b/src/pyft/statements.py
@@ -836,8 +836,12 @@ def removeArraySyntax(doc, concurrent=False, useMnhExpand=True, everywhere=True,
     for parent, elem in toremove:
         parent.remove(elem)
     #And variable creation
+    checknewVarList = []
+    for v in varList:
+        if v.get('new', False) and v not in checknewVarList:
+            checknewVarList.append(v)
     addVar(doc, [(v['scope'], v['n'], 'INTEGER :: {name}'.format(name=v['n']), None)
-                 for v in varList if v.get('new', False)])
+                 for v in checknewVarList])
 
     return doc
 


### PR DESCRIPTION
removeArraySyntax addes new loop-index variables (J1,J2..) multiple times causing compilation error. The commit fixes the consequence by a workaround of multiple occurence of new variable in varList with the attribute new (but not the cause).

Problem reproduction : pyft_tool.py mode_turb_hor_splt.F90 --expandAllArraysConcurrent

The version of the file used is the one ported for mesonh GPU: http://mesonh.aero.obs-mip.fr/gitweb/?p=MNH-git_open_source-lfs.git;a=blob;f=src/PHYEX/turb/mode_turb_hor_splt.f90;h=679196288b12d2e5ee4e5c38511e7c46991680f6;hb=781de77fdcf2ee59256fc6afd2669e2abbda880e

![Capture d’écran du 2024-05-30 16-09-36](https://github.com/UMR-CNRM/pyft/assets/40471444/2566ce5f-3ffa-44dd-ae64-cef74ad50196)
