### PR TITLE
Quentin 02/10/2024 bugfix insertStatement=First takes care of !$acc directives

### DIFF
--- a/src/pyft/openacc.py
+++ b/src/pyft/openacc.py
@@ -157,7 +157,7 @@ class Openacc():
                 if len(arraysIntent) == 0:
                     break
 
-                # 1) !$acc data present()
+                # 1) First !$acc data present()
                 listVar = "!$acc data present ( "
                 count = 0
                 for var in arraysIntent:
@@ -167,11 +167,14 @@ class Openacc():
                     listVar = listVar + var + ", &"
                     count += 1
                 listVarEnd = listVar[:-3]  # remove last comma and &
+                accAddMultipleLines = createExpr(listVarEnd + ')')
+                idx = self.insertStatement(scope.path, self.indent(accAddMultipleLines[0]), first=True)
 
-                for com in createExpr(listVarEnd + ')'):
-                    self.insertStatement(scope.path, self.indent(com), first=True)
-
-                # 2) !$acc end data
+                # 2) multi-lines !$acc &
+                for l,line in enumerate(accAddMultipleLines[1:]):
+                    scope.insert(idx+1+l,line)
+                
+                # 3) !$acc end data
                 comment = createElem('C', text='!$acc end data', tail='\n')
                 self.insertStatement(scope.path, self.indent(comment), first=False)
 

--- a/src/pyft/statements.py
+++ b/src/pyft/statements.py
@@ -1204,6 +1204,7 @@ class Statements():
         :param scope: scope (path or node) in which the statement must be inserted
         :param stmt: statement to insert
         :param first: True to insert it in first position, False to insert it in last position
+        :return: the index of the stmt inserted in scope
         """
         if isinstance(scope, str):
             scope = self.getScopeNode(scope)
@@ -1223,7 +1224,10 @@ class Statements():
             # If an include statements follows, it certainly contains an interface
             while (tag(scope[index]) in ('C', 'include', 'include-stmt') or
                    (tag(scope[index]) == 'cpp' and scope[index].text.startswith('#include'))):
-                index += 1
+                if not scope[index].text.startswith('!$acc'): 
+                    index += 1
+                else:
+                    break
         else:
             # Statement must be inserted before the contains statement
             contains = scope.find('./{*}contains-stmt')
@@ -1238,6 +1242,7 @@ class Statements():
         elif '\n' not in scope[index - 1].tail:
             scope[index - 1].tail += '\n'
         scope.insert(index, stmt)
+        return index
 
     @debugDecor
     def removeStmtNode(self, nodes, simplifyVar, simplifyStruct):


### PR DESCRIPTION
Use of insertStatement(first=True) cause a bug on --addMPPDBCHECK which can add code between a !$acc loop independent and a DO loop.
The changes in statements.py makes it correct.
The changes in openacc.py must be made to keep the fonctionality unchanged.

@SebastienRietteMTO : I added a return value to insertStatement
Is it possible to leave no expected variable to handle the return values to the other calls of insertStatement except the one I was interested in ?
e.g. : grep insertStatement
openacc.py:                idx = self.insertStatement(scope.path, self.indent(accAddMultipleLines[0]), first=True)
applications.py:                    self.insertStatement(scope.path, self.indent(ifMPPDBinit), first=True

Examples are all OK